### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -10,6 +10,8 @@ on:
   # random HH:MM to avoid a load spike on GitHub Actions at 00:00
   - cron: 16 9 * * *
 name: Semgrep
+permissions:
+  contents: read
 jobs:
   semgrep:
     name: Scan


### PR DESCRIPTION
Potential fix for [https://github.com/jonaslejon/malicious-pdf/security/code-scanning/1](https://github.com/jonaslejon/malicious-pdf/security/code-scanning/1)

To fix this, explicitly declare restricted `GITHUB_TOKEN` permissions for the workflow or the `semgrep` job. Since this workflow only checks out code and runs Semgrep, it only needs read access to repository contents. The minimal fix is to set `permissions: contents: read` at the workflow level so it applies to all jobs (there is only `semgrep`), satisfying CodeQL and implementing least privilege.

The best fix without changing functionality is to add a top-level `permissions:` block between the `name: Semgrep` line and the `jobs:` block in `.github/workflows/semgrep.yml`. This will ensure all jobs get a read-only token, while `actions/checkout@v3` continues to function correctly, because it only needs `contents: read` for read-only checkouts. No imports or external libraries are involved; only the YAML structure is updated.

Concretely:
- In `.github/workflows/semgrep.yml`, insert:

```yaml
permissions:
  contents: read
```

- Place it after `name: Semgrep` (line 12) and before `jobs:` (line 13).
No other changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
