### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,4 +187,4 @@ python3 malicious-pdf.py https://your-interact-sh-url --obfuscate 4
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=jonaslejon/malicious-pdf&type=Date)](https://www.star-history.com/#jonaslejon/malicious-pdf&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=jonaslejon/malicious-pdf&type=Date)](https://star-history.dera.page/#jonaslejon/malicious-pdf&Date)


### PR DESCRIPTION
The README's star history chart no longer renders. GitHub tightened its stargazer API, which broke the upstream chart service the badge relies on. This PR repoints the chart to a working mirror (same chart, no API token required) so it displays correctly again. It is a one-line documentation fix with no code changes.